### PR TITLE
Rewrite site to match new multi-page script

### DIFF
--- a/how-it-works.html
+++ b/how-it-works.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>How it works — Make-Your-Own-Steak Machine</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header class="site-header">
+        <div class="logo"><a href="index.html">Make-Your-Own-Steak</a></div>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+            <span class="sr-only">Menu</span>
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <nav id="primary-nav" class="site-nav" aria-label="Primary navigation">
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="how-it-works.html" aria-current="page">How it works</a></li>
+                <li><a href="services.html">Services</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="hero hero--secondary" id="top">
+            <div class="hero__copy">
+                <p class="hero__eyebrow">How it works</p>
+                <h1>Food that respects life.</h1>
+                <p class="hero__tagline">Simple, transparent, and safe.</p>
+                <a class="button button--primary" href="#principle">Explore the process</a>
+            </div>
+            <figure class="hero__visual" aria-labelledby="how-visual-caption">
+                <div class="hero__device hero__device--video" role="img" aria-label="Looped cell growth animation"></div>
+                <figcaption id="how-visual-caption">Multimedia: Looped background video of cell growth animation.</figcaption>
+            </figure>
+        </section>
+
+        <section id="principle" class="section" aria-labelledby="principle-heading">
+            <div class="section__header">
+                <h2 id="principle-heading">The principle</h2>
+                <p>Every steak contains a “recipe”: its DNA. Our technology grows real muscle tissue cell by cell inside a sealed biochamber, no slaughter, antibiotics, or additives. Only pure biology.</p>
+            </div>
+            <div class="media-callout">
+                <div class="media-callout__media" aria-label="Diagram showing DNA to steak progression"></div>
+                <p class="multimedia-note">Media: Diagram showing “DNA → cell → fiber → steak”.</p>
+            </div>
+        </section>
+
+        <section id="process" class="section" aria-labelledby="process-heading">
+            <div class="section__header">
+                <h2 id="process-heading">The process</h2>
+            </div>
+            <ol class="process-list">
+                <li>
+                    <h3>DNA sampling</h3>
+                    <p>A painless swab from a healthy cow is processed in certified labs to create a unique cell line.</p>
+                </li>
+                <li>
+                    <h3>Cell cultivation</h3>
+                    <p>Cells grow in a nutrient-rich medium (amino acids, sugars, vitamins, growth factors). The machine regulates temperature, pH, and oxygen.</p>
+                </li>
+                <li>
+                    <h3>Tissue formation</h3>
+                    <p>Cells multiply into muscle fibers, forming a steak identical in composition to traditional meat.</p>
+                </li>
+                <li>
+                    <h3>Harvest &amp; finishing</h3>
+                    <p>Once ready, the machine alerts the user; steak is removed and cooked; the chamber self-sterilizes.</p>
+                </li>
+            </ol>
+            <p class="multimedia-note">Media: four-step timeline graphic.</p>
+        </section>
+
+        <section id="science" class="section" aria-labelledby="science-heading">
+            <div class="section__header">
+                <h2 id="science-heading">The science</h2>
+                <p>We explain bio-synthesis principles; reference tissue engineering and controlled growth environments.</p>
+            </div>
+            <div class="media-callout">
+                <div class="media-callout__media" aria-label="Short educational animation placeholder"></div>
+                <p class="multimedia-note">Media: Short educational animation.</p>
+            </div>
+        </section>
+
+        <section id="why-it-matters" class="section section--alt" aria-labelledby="ethics-heading">
+            <div class="section__header">
+                <h2 id="ethics-heading">The ethics</h2>
+                <p>Our approach respects animal welfare, empowers producers, and offers consumers full transparency.</p>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer" id="contact">
+        <div class="footer__content">
+            <p>Contact us: <a href="mailto:info@make-yourownsteak.com">info@make-yourownsteak.com</a></p>
+            <p>&copy; <span id="year"></span> Make-Your-Own-Steak. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,291 +2,116 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Resonant Ranch Labs — Make Your Own Steak Machine</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Make-Your-Own-Steak Machine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <canvas id="background-orb"></canvas>
     <header class="site-header">
-        <div class="logo">Resonant Ranch Labs</div>
-        <nav class="site-nav" aria-label="Primary navigation">
-            <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">
-                <span class="sr-only">Toggle navigation</span>
-                <span></span>
-                <span></span>
-                <span></span>
-            </button>
-            <ul id="nav-links">
-                <li><a href="#mission">Mission</a></li>
-                <li><a href="#machine">Machine</a></li>
-                <li><a href="#impact">Impact</a></li>
-                <li><a href="#ethics">Ethics</a></li>
-                <li><a href="#resources">Resources</a></li>
-                <li><a href="#contact">Connect</a></li>
+        <div class="logo"><a href="index.html">Make-Your-Own-Steak</a></div>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+            <span class="sr-only">Menu</span>
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <nav id="primary-nav" class="site-nav" aria-label="Primary navigation">
+            <ul>
+                <li><a href="index.html" aria-current="page">Home</a></li>
+                <li><a href="how-it-works.html">How it works</a></li>
+                <li><a href="services.html">Services</a></li>
+                <li><a href="#contact">Contact</a></li>
             </ul>
         </nav>
     </header>
 
     <main>
         <section class="hero" id="top">
-            <div class="hero__content">
-                <p class="hero__eyebrow">Future of Cultivated Protein</p>
-                <h1>Grow steaks without leaving the pasture.</h1>
-                <p class="hero__description">The Make-Your-Own-Steak Machine empowers farmers to cultivate marbled beef from their herd’s own DNA—slashing emissions, honoring animal welfare, and keeping rural economies thriving.</p>
+            <div class="hero__copy">
+                <p class="hero__eyebrow">Homepage</p>
+                <h1>Make-Your-Own-Steak Machine</h1>
+                <p class="hero__tagline">Real beef, no slaughter.</p>
+                <p class="hero__description">A compact microwave-sized biocooker that grows tonight’s steak from verified cow DNA and nutrient cartridges. Load a DNA capsule, insert nutrient cartridges, press start. Your steak is ready for cooking within hours.</p>
                 <div class="hero__actions">
-                    <a class="button button--primary" href="#machine">Discover the Machine</a>
-                    <button class="button button--ghost" data-scroll-target="#impact">See the impact</button>
+                    <button class="button button--primary" data-scroll-target="#how-it-works">See how it works</button>
+                    <a class="button button--outline" href="services.html#pilot">Join our pilot (farmers &amp; restaurants)</a>
                 </div>
-                <dl class="hero__stats" aria-label="Impact forecast">
-                    <div>
-                        <dt>82%</dt>
-                        <dd>projected reduction in pasture-linked emissions per kilogram of beef</dd>
-                    </div>
-                    <div>
-                        <dt>14</dt>
-                        <dd>days from biopsy to butcher-ready cuts</dd>
-                    </div>
-                    <div>
-                        <dt>0</dt>
-                        <dd>animals slaughtered, dignity preserved</dd>
-                    </div>
-                </dl>
             </div>
-            <div class="hero__visual" role="presentation">
-                <div class="hero__machine">
-                    <div class="machine__ring machine__ring--one"></div>
-                    <div class="machine__ring machine__ring--two"></div>
-                    <div class="machine__core">
-                        <span>DNA</span>
-                    </div>
-                </div>
-                <p class="hero__caption">Bio-reactor pods sync with existing barn infrastructure, powered by wind or solar.</p>
+            <figure class="hero__visual" aria-labelledby="hero-visual-caption">
+                <div class="hero__device" role="img" aria-label="Microwave-sized biocooker glowing through transparent chamber"></div>
+                <figcaption id="hero-visual-caption">Microwave-size biocooker glowing through a transparent chamber.</figcaption>
+            </figure>
+        </section>
+
+        <section class="notice" aria-labelledby="notice-heading">
+            <div class="container">
+                <h2 id="notice-heading">Instructions &amp; safety notice</h2>
+                <p>We work with certified partners to introduce this technology via controlled pilots. Make sure to always follow the proper hygiene steps and approved guidelines, as indicated on-screen. Regional food safety approvals apply.</p>
             </div>
         </section>
 
-        <section id="mission" class="section section--two-column">
-            <div class="section__intro">
-                <h2>Why transform the meat industry from within?</h2>
-                <p>Climate change, animal welfare, and rural livelihoods are entangled. Our approach invites farmers—the stewards of land and tradition—to lead a transition that keeps steak on the table without heating the planet or harming livestock.</p>
+        <section id="how-it-works" class="section" aria-labelledby="how-heading">
+            <div class="section__header">
+                <h2 id="how-heading">How does this work?</h2>
+                <p class="section__intro">Source ethically, load &amp; verify, grow, prepare &amp; enjoy.</p>
             </div>
-            <div class="section__content">
-                <article class="card">
-                    <h3>Climate action rooted in practice</h3>
-                    <p>By decoupling meat from methane-heavy herds, the machine reduces land-use pressure and water consumption while keeping carbon stored in soil through regenerative grazing reserved for breeding animals.</p>
+            <div class="steps">
+                <article class="step">
+                    <h3>Source ethically</h3>
+                    <p>Verified DNA is sampled from healthy and responsibly kept cows by participating farmers. Welfare data travel with the NFC chip on the DNA capsule.</p>
                 </article>
-                <article class="card">
-                    <h3>Ethics in everyday work</h3>
-                    <p>Farmers cultivate cells instead of slaughtering animals, aligning daily routines with animal dignity and reducing occupational trauma without forcing dietary change on communities.</p>
+                <article class="step">
+                    <h3>Load &amp; verify</h3>
+                    <p>Insert the DNA capsule and nutrient cartridges. The touchscreen reads NFC chips, verifies origin, and shows estimated grow time and CO₂ / water savings.</p>
                 </article>
-                <article class="card">
-                    <h3>Rural economies stay vibrant</h3>
-                    <p>Ownership stays local. Farmers remain the trusted suppliers, now offering premium cruelty-free cuts cultivated with their herd’s terroir.</p>
+                <article class="step">
+                    <h3>Grow</h3>
+                    <p>Inside the transparent chamber, muscle tissue forms layer by layer under sterile, controlled conditions.</p>
                 </article>
+                <article class="step">
+                    <h3>Prepare &amp; enjoy</h3>
+                    <p>Remove, rest, season, and cook your steak — real meat taste and texture, no slaughter.</p>
+                </article>
+            </div>
+            <div class="section__cta">
+                <a class="button button--ghost" href="how-it-works.html">Learn the science</a>
+                <p class="multimedia-note">Multimedia: Step-by-step infographic (4 icons + short captions).</p>
             </div>
         </section>
 
-        <section id="machine" class="section section--machine">
-            <div class="section__intro">
-                <h2>The Make-Your-Own-Steak Machine</h2>
-                <p>Compact, modular bioreactors that integrate with existing barns. Select DNA from your healthiest cattle, feed the growth medium, and harvest fully structured steaks.</p>
+        <section class="impact" aria-labelledby="impact-heading">
+            <div class="impact__header">
+                <h2 id="impact-heading">Which problems do we solve?</h2>
+                <p class="tagline">Meat without compromise.</p>
             </div>
-            <div class="machine-steps" role="tablist" aria-label="Machine walkthrough">
-                <button class="machine-step is-active" role="tab" aria-selected="true" aria-controls="step-content-1" id="step-tab-1">1. Preserve identity</button>
-                <button class="machine-step" role="tab" aria-selected="false" aria-controls="step-content-2" id="step-tab-2">2. Seed &amp; scaffold</button>
-                <button class="machine-step" role="tab" aria-selected="false" aria-controls="step-content-3" id="step-tab-3">3. Grow &amp; monitor</button>
-                <button class="machine-step" role="tab" aria-selected="false" aria-controls="step-content-4" id="step-tab-4">4. Harvest &amp; share</button>
-            </div>
-            <div class="machine-step__content" id="step-content-1" role="tabpanel" aria-labelledby="step-tab-1">
-                <h3>Preserve local flavor</h3>
-                <p>Farmers take a painless biopsy, store the genome signature, and calibrate marbling preferences. Each farm keeps exclusive rights to its strains, honoring heritage breeding.</p>
-            </div>
-            <div class="machine-step__content" id="step-content-2" role="tabpanel" aria-labelledby="step-tab-2" hidden>
-                <h3>Seed &amp; scaffold</h3>
-                <p>Cells are layered onto a mycelium-based scaffold grown from agricultural byproducts. The scaffold composts after use, cycling nutrients back into the farm.</p>
-            </div>
-            <div class="machine-step__content" id="step-content-3" role="tabpanel" aria-labelledby="step-tab-3" hidden>
-                <h3>Grow &amp; monitor</h3>
-                <p>AI-assisted dashboards track growth, energy use, and nutrient uptake. Farmers receive alerts when adjustments maintain premium quality and compliance.</p>
-            </div>
-            <div class="machine-step__content" id="step-content-4" role="tabpanel" aria-labelledby="step-tab-4" hidden>
-                <h3>Harvest &amp; share</h3>
-                <p>Steaks mature in fourteen days. Vacuum-sealed cuts are certified with QR provenance, enabling transparent storytelling at markets and restaurants.</p>
-            </div>
-        </section>
-
-        <section id="impact" class="section section--impact">
-            <div class="section__intro">
-                <h2>Forecasting impact across ecosystems</h2>
-                <p>Select an impact lens to explore how techno-moral foresight is built into every deployment.</p>
-            </div>
-            <div class="impact-lenses" role="tablist" aria-label="Impact lenses">
-                <button class="impact-lens is-active" data-impact="environmental" role="tab" aria-selected="true">Environmental</button>
-                <button class="impact-lens" data-impact="ethical" role="tab" aria-selected="false">Animal Dignity</button>
-                <button class="impact-lens" data-impact="economic" role="tab" aria-selected="false">Economic</button>
-                <button class="impact-lens" data-impact="social" role="tab" aria-selected="false">Social</button>
-            </div>
-            <div class="impact-panels">
-                <article class="impact-panel" data-impact="environmental">
-                    <h3>Closed-loop energy &amp; water</h3>
-                    <ul>
-                        <li>Bioreactors powered by on-site renewables reduce grid strain.</li>
-                        <li>Condensed water recovery cuts usage by 68% compared to feedlots.</li>
-                        <li>Spent medium feeds algae digesters, turning waste into fertilizer.</li>
-                    </ul>
+            <div class="impact__grid">
+                <article>
+                    <h3>Environmental impact</h3>
+                    <p>Traditional beef is a major source of water use and greenhouse gases. Growing meat directly from DNA removes slaughter, transport, and processing, cutting water use by ≈ 11 L per kilo and drastically lowering CO₂ emissions (source: National Advisory Committee on Microbiological Criteria for Food, 2018-2020).</p>
                 </article>
-                <article class="impact-panel" data-impact="ethical" hidden>
-                    <h3>Animal dignity in daily operations</h3>
-                    <ul>
-                        <li>Routine shifts from slaughter schedules to cell cultivation care.</li>
-                        <li>Veterinary roles pivot toward long-term herd wellbeing.</li>
-                        <li>Transparent welfare metrics become a new marketing standard.</li>
-                    </ul>
+                <article>
+                    <h3>Moral concerns</h3>
+                    <p>The debate between animal-welfare and meat-lover camps is reframed: DNA is collected non-invasively from well-kept cows, eliminating slaughter guilt.</p>
                 </article>
-                <article class="impact-panel" data-impact="economic" hidden>
-                    <h3>Farmer-owned intellectual terroir</h3>
-                    <ul>
-                        <li>DNA libraries stay farm-specific, protecting premium flavors.</li>
-                        <li>Financing includes cooperative ownership to avoid corporate capture.</li>
-                        <li>Milk and egg producers diversify with hybrid protein portfolios.</li>
-                    </ul>
-                </article>
-                <article class="impact-panel" data-impact="social" hidden>
-                    <h3>Transparent community benefit agreements</h3>
-                    <ul>
-                        <li>Local apprenticeships translate bioprocess skills into rural jobs.</li>
-                        <li>Public tasting labs foster dialogue about culture and cuisine.</li>
-                        <li>Equity fund subsidizes machines for smallholder and Indigenous farms.</li>
-                    </ul>
+                <article>
+                    <h3>Supply chain disruption</h3>
+                    <p>The tech decentralizes meat production. Farmers become DNA caretakers and machine operators; restaurants produce steaks in-house; consumers gain full transparency. Power shifts back to local producers, creating fresher and more resilient food systems.</p>
                 </article>
             </div>
-        </section>
-
-        <section id="ethics" class="section section--ethics">
-            <div class="section__intro">
-                <h2>Anticipating techno-moral side effects</h2>
-                <p>We probe beyond the obvious to surface hidden stakeholders, emergent behaviors, and shifting responsibilities before deployment.</p>
-            </div>
-            <div class="ethics-grid">
-                <article class="ethics-card">
-                    <h3>Unintended users</h3>
-                    <p>Chefs, cultured leather artisans, and biomedical labs can license modules. Governance charters outline secondary uses and require revenue sharing with the originating farm cooperative.</p>
-                </article>
-                <article class="ethics-card">
-                    <h3>Shifting roles</h3>
-                    <p>Farmhands become bioprocess stewards. Training pathways certify new competencies while preserving pasturecraft knowledge through mentorship stipends.</p>
-                </article>
-                <article class="ethics-card">
-                    <h3>Visibility of stakeholders</h3>
-                    <p>Dashboards highlight lifecycle data from feed suppliers to local councils, making supply chain actors legible so communities can co-create oversight boards.</p>
-                </article>
-                <article class="ethics-card">
-                    <h3>New rights &amp; obligations</h3>
-                    <p>Biofabrication makes traceability enforceable; consumers gain the right to provenance transparency, and farms commit to publishing welfare metrics quarterly.</p>
-                </article>
-                <article class="ethics-card">
-                    <h3>Access &amp; justice</h3>
-                    <p>Tiered pricing and cooperative lending prioritize historically marginalized farmers. Urban food labs partner to distribute steaks to food deserts at regulated prices.</p>
-                </article>
-                <article class="ethics-card">
-                    <h3>Valuing legacy skills</h3>
-                    <p>Artisanal butchery informs texture calibration. A digital archive records heritage techniques, ensuring they guide machine presets rather than vanish.</p>
-                </article>
-            </div>
-        </section>
-
-        <section id="resources" class="section section--resources">
-            <div class="section__intro">
-                <h2>Plan deployments with precision</h2>
-                <p>Adjust production variables to see how the machine scales within real farm constraints.</p>
-            </div>
-            <div class="resource-simulator" role="group" aria-label="Resource simulator">
-                <label for="batch-slider">Weekly batch count</label>
-                <input type="range" id="batch-slider" min="1" max="12" value="6" step="1" />
-                <output id="batch-output" for="batch-slider">6 batches</output>
-                <div class="resource-cards">
-                    <div class="resource-card">
-                        <h3>Biomass feed</h3>
-                        <p><span id="feed-value">1.8</span> tonnes of cellulose medium</p>
-                    </div>
-                    <div class="resource-card">
-                        <h3>Energy demand</h3>
-                        <p><span id="energy-value">4.2</span> MWh renewable energy</p>
-                    </div>
-                    <div class="resource-card">
-                        <h3>Protein yield</h3>
-                        <p><span id="yield-value">2.4</span> tonnes boneless steak</p>
-                    </div>
-                </div>
-                <p class="resource-note">Outputs capped to prevent market flooding and keep pricing stable. Licensing agreements require community impact audits once production surpasses 9 batches.</p>
-            </div>
-        </section>
-
-        <section class="section section--stories">
-            <div class="section__intro">
-                <h2>Field notes from early collaborators</h2>
-                <p>Farmers and partners share how the machine is reshaping their work and communities.</p>
-            </div>
-            <div class="stories-marquee" aria-live="polite">
-                <article class="story">
-                    <p>“We still graze our herd, but now the calmest cows become the DNA donors. My teenagers are excited to stay on the farm as biofabrication apprentices.”</p>
-                    <span>— Amaia, Basque cooperative farmer</span>
-                </article>
-                <article class="story">
-                    <p>“Our culinary school streams live tastings with farmers, letting students compare pasture-raised and cultured steaks from the same lineage.”</p>
-                    <span>— Jordan, community college instructor</span>
-                </article>
-                <article class="story">
-                    <p>“The machine freed up water, so we restored wetlands that now offset our remaining emissions and host eco-tourism workshops.”</p>
-                    <span>— Leila, regenerative rancher</span>
-                </article>
-            </div>
-        </section>
-
-        <section id="contact" class="section section--contact">
-            <div class="section__intro">
-                <h2>Co-design your steak future</h2>
-                <p>Join the next pilot cohort. We co-create deployment plans with farmers, chefs, regulators, and community advocates.</p>
-            </div>
-            <form class="contact-form">
-                <div class="form-field">
-                    <label for="name">Name</label>
-                    <input type="text" id="name" name="name" placeholder="Your name" required />
-                </div>
-                <div class="form-field">
-                    <label for="email">Email</label>
-                    <input type="email" id="email" name="email" placeholder="you@farmcoop.org" required />
-                </div>
-                <div class="form-field">
-                    <label for="role">Role</label>
-                    <select id="role" name="role">
-                        <option>Farmer or Rancher</option>
-                        <option>Chef or Food Entrepreneur</option>
-                        <option>Policy Maker</option>
-                        <option>Researcher</option>
-                        <option>Investor</option>
-                    </select>
-                </div>
-                <div class="form-field form-field--full">
-                    <label for="message">Tell us about your goals</label>
-                    <textarea id="message" name="message" rows="4" placeholder="Share your context, ambitions, and questions"></textarea>
-                </div>
-                <button class="button button--primary" type="submit">Request a pilot blueprint</button>
-            </form>
-            <div class="contact-meta">
-                <p><strong>Resonant Ranch Labs HQ</strong><br />2040 Stewardship Way, Boulder, CO</p>
-                <p><strong>Inquiries</strong><br /><a href="mailto:hello@resonant.ranch">hello@resonant.ranch</a></p>
-                <p><strong>Cooperative Hotline</strong><br />+1 (970) 555-1400</p>
+            <div class="section__cta">
+                <a class="button button--primary" href="how-it-works.html#why-it-matters">Discover why this matters</a>
             </div>
         </section>
     </main>
 
-    <footer class="site-footer">
-        <p>&copy; 2040 Resonant Ranch Labs Cooperative. Cultivating ethical abundance together.</p>
-        <button class="back-to-top" data-scroll-target="#top">Back to top</button>
+    <footer class="site-footer" id="contact">
+        <div class="footer__content">
+            <p>Contact us: <a href="mailto:info@make-yourownsteak.com">info@make-yourownsteak.com</a></p>
+            <p>&copy; <span id="year"></span> Make-Your-Own-Steak. All rights reserved.</p>
+        </div>
     </footer>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,34 +1,26 @@
 const navToggle = document.querySelector('.nav-toggle');
-const navLinks = document.getElementById('nav-links');
-const buttonsWithScroll = document.querySelectorAll('[data-scroll-target]');
-const machineTabs = document.querySelectorAll('.machine-step');
-const machinePanels = document.querySelectorAll('.machine-step__content');
-const lensButtons = document.querySelectorAll('.impact-lens');
-const impactPanels = document.querySelectorAll('.impact-panel');
-const batchSlider = document.getElementById('batch-slider');
-const batchOutput = document.getElementById('batch-output');
-const feedValue = document.getElementById('feed-value');
-const energyValue = document.getElementById('energy-value');
-const yieldValue = document.getElementById('yield-value');
-const backToTop = document.querySelector('.back-to-top');
+const nav = document.getElementById('primary-nav');
+const scrollButtons = document.querySelectorAll('[data-scroll-target]');
+const yearEl = document.getElementById('year');
 
-if (navToggle) {
+if (navToggle && nav) {
     navToggle.addEventListener('click', () => {
         const expanded = navToggle.getAttribute('aria-expanded') === 'true';
         navToggle.setAttribute('aria-expanded', String(!expanded));
-        navLinks.classList.toggle('is-open');
+        nav.classList.toggle('is-open');
     });
 
-    navLinks.querySelectorAll('a').forEach(link => {
+    nav.querySelectorAll('a').forEach(link => {
         link.addEventListener('click', () => {
             navToggle.setAttribute('aria-expanded', 'false');
-            navLinks.classList.remove('is-open');
+            nav.classList.remove('is-open');
         });
     });
 }
 
-buttonsWithScroll.forEach(button => {
-    button.addEventListener('click', () => {
+scrollButtons.forEach(button => {
+    button.addEventListener('click', event => {
+        event.preventDefault();
         const target = document.querySelector(button.dataset.scrollTarget);
         if (target) {
             target.scrollIntoView({ behavior: 'smooth' });
@@ -36,103 +28,6 @@ buttonsWithScroll.forEach(button => {
     });
 });
 
-if (backToTop) {
-    backToTop.addEventListener('click', () => {
-        document.querySelector('#top').scrollIntoView({ behavior: 'smooth' });
-    });
-}
-
-machineTabs.forEach(tab => {
-    tab.addEventListener('click', () => {
-        machineTabs.forEach(btn => btn.classList.remove('is-active'));
-        machinePanels.forEach(panel => {
-            panel.hidden = panel.id !== tab.getAttribute('aria-controls');
-        });
-        tab.classList.add('is-active');
-    });
-});
-
-lensButtons.forEach(button => {
-    button.addEventListener('click', () => {
-        lensButtons.forEach(btn => {
-            btn.classList.remove('is-active');
-            btn.setAttribute('aria-selected', 'false');
-        });
-        button.classList.add('is-active');
-        button.setAttribute('aria-selected', 'true');
-
-        const selectedImpact = button.dataset.impact;
-        impactPanels.forEach(panel => {
-            const isActive = panel.dataset.impact === selectedImpact;
-            panel.hidden = !isActive;
-        });
-    });
-});
-
-if (batchSlider) {
-    const updateSimulator = value => {
-        batchOutput.textContent = `${value} ${value === '1' ? 'batch' : 'batches'}`;
-        const batches = Number(value);
-        const feed = (batches * 0.3).toFixed(1);
-        const energy = (batches * 0.7).toFixed(1);
-        const protein = (batches * 0.4).toFixed(1);
-        feedValue.textContent = feed;
-        energyValue.textContent = energy;
-        yieldValue.textContent = protein;
-    };
-
-    updateSimulator(batchSlider.value);
-    batchSlider.addEventListener('input', event => updateSimulator(event.target.value));
-}
-
-const canvas = document.getElementById('background-orb');
-if (canvas) {
-    const ctx = canvas.getContext('2d');
-    let width, height;
-    const orbs = Array.from({ length: 18 }, () => ({
-        x: Math.random(),
-        y: Math.random(),
-        radius: 80 + Math.random() * 140,
-        speedX: (Math.random() - 0.5) * 0.0008,
-        speedY: (Math.random() - 0.5) * 0.0008,
-        hue: 180 + Math.random() * 160,
-        alpha: 0.06 + Math.random() * 0.08
-    }));
-
-    const resize = () => {
-        width = canvas.width = window.innerWidth * window.devicePixelRatio;
-        height = canvas.height = window.innerHeight * window.devicePixelRatio;
-        ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
-    };
-
-    const render = () => {
-        ctx.clearRect(0, 0, width, height);
-        orbs.forEach(orb => {
-            orb.x += orb.speedX;
-            orb.y += orb.speedY;
-            if (orb.x < -0.2 || orb.x > 1.2) orb.speedX *= -1;
-            if (orb.y < -0.2 || orb.y > 1.2) orb.speedY *= -1;
-
-            const gradient = ctx.createRadialGradient(
-                orb.x * window.innerWidth,
-                orb.y * window.innerHeight,
-                0,
-                orb.x * window.innerWidth,
-                orb.y * window.innerHeight,
-                orb.radius
-            );
-            gradient.addColorStop(0, `hsla(${orb.hue}, 95%, 65%, ${orb.alpha})`);
-            gradient.addColorStop(1, 'transparent');
-
-            ctx.fillStyle = gradient;
-            ctx.beginPath();
-            ctx.arc(orb.x * window.innerWidth, orb.y * window.innerHeight, orb.radius, 0, Math.PI * 2);
-            ctx.fill();
-        });
-        requestAnimationFrame(render);
-    };
-
-    resize();
-    render();
-    window.addEventListener('resize', resize, { passive: true });
+if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
 }

--- a/services.html
+++ b/services.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Services — Make-Your-Own-Steak Machine</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header class="site-header">
+        <div class="logo"><a href="index.html">Make-Your-Own-Steak</a></div>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+            <span class="sr-only">Menu</span>
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <nav id="primary-nav" class="site-nav" aria-label="Primary navigation">
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="how-it-works.html">How it works</a></li>
+                <li><a href="services.html" aria-current="page">Services</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="section" aria-labelledby="services-heading">
+            <div class="section__header">
+                <h1 id="services-heading">More than a machine: an ecosystem.</h1>
+            </div>
+            <div class="services-grid">
+                <article>
+                    <h2>The Machines</h2>
+                    <p><strong>Compact (kitchen size):</strong> Microwave-sized for homes/restaurants.</p>
+                    <p><strong>Industrial (batch size):</strong> Washing-machine scale for larger output.</p>
+                    <p class="multimedia-note">Media: Side-by-side product photos.</p>
+                </article>
+                <article>
+                    <h2>DNA Sampling Kits</h2>
+                    <p>Safe, painless kits for farmers; processed in certified labs into traceable DNA capsules ensuring ethical sourcing.</p>
+                    <p class="multimedia-note">Media: Photo + diagram of kit.</p>
+                </article>
+                <article>
+                    <h2>Nutrient Cartridges</h2>
+                    <p>Balanced, pre-packed blends verified for food safety and optimized for taste and texture.</p>
+                    <p class="multimedia-note">Media: Carousel of cartridge types.</p>
+                </article>
+                <article>
+                    <h2>Transition Programs for Farmers</h2>
+                    <p>Consultancy, training, and support for shifting from livestock raising to DNA caretaking and machine operation, creating new income streams and reducing mass farming.</p>
+                </article>
+                <article>
+                    <h2>Data services</h2>
+                    <p>Dashboard showing water and CO₂ savings + demand trends.</p>
+                    <p class="multimedia-note">Media: Dashboard screenshot.</p>
+                </article>
+                <article>
+                    <h2>Consumer education</h2>
+                    <p>Workshops and guides explaining lab-grown meat to build trust and pride in sustainable choices.</p>
+                </article>
+                <article>
+                    <h2>Maintenance &amp; Certification</h2>
+                    <p>Regular calibration, software updates, and quality control meeting EU food-safety standards.</p>
+                    <p class="multimedia-note">Media: Certification badges icon row.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="notice" aria-labelledby="reassurance-heading">
+            <div class="container">
+                <h2 id="reassurance-heading">Reassurance</h2>
+                <p>All services comply with European food safety standards and are supported by certified biotech labs.</p>
+            </div>
+        </section>
+
+        <section id="pilot" class="section" aria-labelledby="pilot-heading">
+            <div class="section__header">
+                <h2 id="pilot-heading">From pilot to plate.</h2>
+                <p>Currently available through controlled pilots in the Netherlands.</p>
+            </div>
+            <div class="pilot-grid">
+                <div>
+                    <p>We are onboarding:</p>
+                    <ul>
+                        <li>Farmers supplying DNA and operating machines.</li>
+                        <li>Restaurants/ retailers serving lab-grown steaks.</li>
+                        <li>Research partners developing safety and labeling frameworks.</li>
+                    </ul>
+                    <p class="subtext">Consumer versions pending regulatory approval; pre-registration soon.</p>
+                    <a class="button button--primary" href="mailto:info@make-yourownsteak.com?subject=Pilot%20access%20request">Apply for pilot access</a>
+                </div>
+                <figure aria-labelledby="pilot-media-caption">
+                    <div class="map-placeholder" role="img" aria-label="Map of Netherlands with pilot locations"></div>
+                    <figcaption id="pilot-media-caption">Media: Map of Netherlands with pilot locations.</figcaption>
+                </figure>
+            </div>
+        </section>
+
+        <section class="section section--alt" aria-labelledby="directory-heading">
+            <div class="section__header">
+                <h2 id="directory-heading">Find your nearest pilot partner.</h2>
+                <p>Pilot “meat kits” (DNA capsules + nutrient cartridges) are available only at approved locations:</p>
+            </div>
+            <ul class="checklist">
+                <li>Partner restaurants.</li>
+                <li>Certified farmers offering local DNA capsules.</li>
+                <li>Selected retailers/ online platforms.</li>
+            </ul>
+            <div class="map-widget">
+                <div id="pilot-map" class="map-widget__placeholder" role="img" aria-label="Interactive map widget placeholder"></div>
+                <p class="notice-text">Notice: Availability depends on regional approvals and partnerships.</p>
+                <a class="button button--ghost" href="#pilot-map">See locations near you</a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer" id="contact">
+        <div class="footer__content">
+            <p>Contact us: <a href="mailto:info@make-yourownsteak.com">info@make-yourownsteak.com</a></p>
+            <p>&copy; <span id="year"></span> Make-Your-Own-Steak. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,13 @@
 :root {
-    --bg: #04030f;
-    --accent: #ff5c97;
-    --accent-secondary: #4ff0e3;
-    --text: #f6f7ff;
-    --muted: rgba(246, 247, 255, 0.65);
-    --card-bg: rgba(10, 9, 25, 0.7);
-    --border: rgba(255, 255, 255, 0.1);
-    --gradient: linear-gradient(135deg, rgba(255, 92, 151, 0.4), rgba(79, 240, 227, 0.3));
+    --bg: #05050c;
+    --surface: #101020;
+    --surface-alt: #181830;
+    --accent: #ff6b6b;
+    --accent-dark: #ff3b6a;
+    --text: #f5f7ff;
+    --muted: #cdd2f6;
+    --muted-strong: #9aa2d8;
+    --border: rgba(255, 255, 255, 0.08);
     font-size: 16px;
 }
 
@@ -18,34 +19,36 @@ body {
     margin: 0;
     font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     color: var(--text);
-    background: radial-gradient(circle at top left, rgba(79, 240, 227, 0.1), transparent 45%), radial-gradient(circle at bottom right, rgba(255, 92, 151, 0.1), transparent 40%), var(--bg);
+    background: radial-gradient(circle at top left, rgba(255, 107, 107, 0.12), transparent 50%),
+        radial-gradient(circle at bottom right, rgba(85, 150, 255, 0.18), transparent 45%),
+        var(--bg);
     min-height: 100vh;
-    overflow-x: hidden;
 }
 
-canvas#background-orb {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    z-index: -1;
+a {
+    color: inherit;
+}
+
+a:hover,
+a:focus-visible {
+    color: var(--accent);
 }
 
 .site-header {
-    position: sticky;
-    top: 0;
-    z-index: 10;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1.5rem clamp(1.5rem, 5vw, 4rem);
-    background: rgba(4, 3, 15, 0.72);
-    backdrop-filter: blur(16px);
+    padding: 1.25rem clamp(1rem, 4vw, 3rem);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: rgba(5, 5, 12, 0.9);
+    backdrop-filter: blur(18px);
     border-bottom: 1px solid var(--border);
 }
 
-.logo {
+.logo a {
+    text-decoration: none;
     font-weight: 800;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -53,482 +56,61 @@ canvas#background-orb {
 }
 
 .site-nav ul {
-    display: flex;
-    gap: 1.5rem;
     list-style: none;
     margin: 0;
     padding: 0;
+    display: flex;
+    gap: 1.5rem;
 }
 
 .site-nav a {
-    color: var(--muted);
     text-decoration: none;
     font-weight: 600;
-    font-size: 0.9rem;
+    font-size: 0.95rem;
+    color: var(--muted);
     position: relative;
+    padding-bottom: 0.2rem;
+}
+
+.site-nav a[aria-current="page"] {
+    color: var(--text);
 }
 
 .site-nav a::after {
     content: '';
     position: absolute;
     left: 0;
-    bottom: -0.4rem;
+    bottom: 0;
     width: 100%;
     height: 2px;
     background: var(--accent);
     transform: scaleX(0);
     transform-origin: left;
-    transition: transform 0.3s ease;
+    transition: transform 0.2s ease;
 }
 
 .site-nav a:hover::after,
-.site-nav a:focus-visible::after {
+.site-nav a:focus-visible::after,
+.site-nav a[aria-current="page"]::after {
     transform: scaleX(1);
 }
 
 .nav-toggle {
     display: none;
-}
-
-main {
-    padding: 0 clamp(1.5rem, 5vw, 4rem) 6rem;
-}
-
-.hero {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    align-items: center;
-    gap: 3rem;
-    padding: 6rem 0 4rem;
-}
-
-.hero__eyebrow {
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    font-size: 0.85rem;
-    color: var(--accent-secondary);
-}
-
-.hero h1 {
-    font-size: clamp(2.8rem, 5vw, 4.5rem);
-    margin: 1rem 0;
-    line-height: 1.05;
-}
-
-.hero__description {
-    font-size: 1.1rem;
-    color: var(--muted);
-    max-width: 34ch;
-}
-
-.hero__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    margin: 2rem 0 2.5rem;
-}
-
-.button {
-    padding: 0.9rem 1.8rem;
-    border-radius: 999px;
-    font-weight: 700;
-    border: 1px solid transparent;
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.button:focus-visible {
-    outline: 3px solid var(--accent-secondary);
-    outline-offset: 3px;
-}
-
-.button--primary {
-    background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
-    color: #04030f;
-    box-shadow: 0 18px 40px rgba(255, 92, 151, 0.35);
-}
-
-.button--primary:hover {
-    transform: translateY(-4px);
-}
-
-.button--ghost {
     background: transparent;
-    color: var(--text);
-    border-color: var(--accent-secondary);
-}
-
-.button--ghost:hover {
-    transform: translateY(-2px);
-}
-
-.hero__stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 1.5rem;
-    font-size: 0.9rem;
-    color: var(--muted);
-}
-
-.hero__stats dt {
-    font-size: 2.6rem;
-    font-weight: 800;
-    color: var(--accent-secondary);
-}
-
-.hero__visual {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
-}
-
-.hero__machine {
-    position: relative;
-    width: clamp(240px, 28vw, 320px);
-    height: clamp(240px, 28vw, 320px);
-}
-
-.machine__ring {
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    border: 2px solid rgba(79, 240, 227, 0.5);
-    animation: pulse 8s linear infinite;
-}
-
-.machine__ring--two {
-    border-color: rgba(255, 92, 151, 0.5);
-    animation-delay: -4s;
-}
-
-.machine__core {
-    position: absolute;
-    inset: 25%;
-    background: var(--gradient);
-    border-radius: 32% 68% 44% 56% / 52% 40% 60% 48%;
-    display: grid;
-    place-items: center;
-    font-weight: 800;
-    color: #04030f;
-    font-size: 1.2rem;
-}
-
-.hero__caption {
-    max-width: 28ch;
-    text-align: center;
-    color: var(--muted);
-}
-
-.section {
-    margin: 5rem 0;
-}
-
-.section__intro {
-    max-width: 70ch;
-    margin-bottom: 2.5rem;
-}
-
-.section__intro h2 {
-    font-size: clamp(2rem, 4vw, 3rem);
-    margin-bottom: 1rem;
-}
-
-.section__intro p {
-    color: var(--muted);
-    font-size: 1.05rem;
-}
-
-.section--two-column .section__content {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
-}
-
-.card {
-    padding: 1.8rem;
-    border-radius: 1.5rem;
-    background: var(--card-bg);
-    border: 1px solid var(--border);
-    position: relative;
-    overflow: hidden;
-}
-
-.card::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(255, 92, 151, 0.15), rgba(79, 240, 227, 0));
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.card:hover::before {
-    opacity: 1;
-}
-
-.card h3 {
-    margin-top: 0;
-    margin-bottom: 0.75rem;
-}
-
-.section--machine {
-    position: relative;
-}
-
-.machine-steps {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0.75rem;
-    margin-bottom: 2rem;
-}
-
-.machine-step {
-    padding: 0.9rem 1rem;
-    border-radius: 0.75rem;
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.05);
-    color: var(--muted);
-    font-weight: 600;
+    border: none;
+    color: inherit;
+    padding: 0.35rem;
     cursor: pointer;
-    transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
-.machine-step.is-active {
-    background: var(--gradient);
-    color: #04030f;
-    border-color: transparent;
-}
-
-.machine-step__content {
-    background: var(--card-bg);
-    padding: 2rem;
-    border-radius: 1.5rem;
-    border: 1px solid var(--border);
-    min-height: 160px;
-}
-
-.section--impact .impact-lenses {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-bottom: 2rem;
-}
-
-.impact-lens {
-    padding: 0.7rem 1.1rem;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.05);
-    color: var(--muted);
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.3s ease, color 0.3s ease;
-}
-
-.impact-lens.is-active {
-    background: var(--gradient);
-    color: #04030f;
-}
-
-.impact-panels {
-    display: grid;
-}
-
-.impact-panel {
-    background: var(--card-bg);
-    border-radius: 1.5rem;
-    border: 1px solid var(--border);
-    padding: 2rem;
-    animation: fadeIn 0.5s ease;
-}
-
-.impact-panel ul {
-    padding-left: 1.2rem;
-    color: var(--muted);
-}
-
-.section--ethics .ethics-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 1.5rem;
-}
-
-.ethics-card {
-    padding: 1.8rem;
-    border-radius: 1.5rem;
-    background: var(--card-bg);
-    border: 1px solid var(--border);
-    position: relative;
-    overflow: hidden;
-}
-
-.ethics-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(160deg, rgba(79, 240, 227, 0.1), rgba(255, 92, 151, 0));
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.ethics-card:hover::after {
-    opacity: 1;
-}
-
-.section--resources .resource-simulator {
-    background: var(--card-bg);
-    border-radius: 1.8rem;
-    border: 1px solid var(--border);
-    padding: 2.5rem;
-}
-
-.section--resources label {
+.nav-toggle span:not(.sr-only) {
     display: block;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-}
-
-#batch-slider {
-    width: 100%;
-    margin-bottom: 1rem;
-}
-
-#batch-output {
-    display: inline-block;
-    font-weight: 700;
-    background: rgba(255, 255, 255, 0.08);
-    padding: 0.4rem 0.9rem;
-    border-radius: 999px;
-    margin-bottom: 2rem;
-}
-
-.resource-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.resource-card {
-    padding: 1.5rem;
-    border-radius: 1.2rem;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid var(--border);
-    text-align: center;
-}
-
-.resource-card span {
-    font-size: 2rem;
-    font-weight: 800;
-    color: var(--accent-secondary);
-}
-
-.resource-note {
-    color: var(--muted);
-    font-size: 0.95rem;
-}
-
-.section--stories .stories-marquee {
-    display: grid;
-    gap: 1.5rem;
-    position: relative;
-}
-
-.story {
-    padding: 1.6rem;
-    border-radius: 1.5rem;
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.05);
-    box-shadow: 0 18px 40px rgba(4, 3, 15, 0.35);
-    animation: float 12s ease-in-out infinite;
-}
-
-.story:nth-child(2) {
-    animation-delay: -4s;
-}
-
-.story:nth-child(3) {
-    animation-delay: -8s;
-}
-
-.story span {
-    display: block;
-    margin-top: 1rem;
-    color: var(--accent-secondary);
-    font-weight: 600;
-}
-
-.section--contact {
-    display: grid;
-    gap: 2rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.contact-form {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem 1.5rem;
-    background: var(--card-bg);
-    border-radius: 1.5rem;
-    border: 1px solid var(--border);
-    padding: 2rem;
-}
-
-.form-field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.form-field--full {
-    grid-column: 1 / -1;
-}
-
-input, select, textarea {
-    padding: 0.75rem 1rem;
-    border-radius: 0.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--text);
-    font: inherit;
-}
-
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-    outline: 2px solid var(--accent-secondary);
-    outline-offset: 2px;
-}
-
-.contact-meta {
-    background: rgba(255, 255, 255, 0.04);
-    border-radius: 1.5rem;
-    border: 1px solid var(--border);
-    padding: 2rem;
-    color: var(--muted);
-}
-
-.site-footer {
-    padding: 2rem clamp(1.5rem, 5vw, 4rem) 3rem;
-    text-align: center;
-    color: var(--muted);
-    border-top: 1px solid var(--border);
-    background: rgba(4, 3, 15, 0.85);
-}
-
-.back-to-top {
-    margin-top: 1rem;
-    background: transparent;
-    border: 1px solid var(--accent-secondary);
-    color: var(--text);
-    border-radius: 999px;
-    padding: 0.7rem 1.6rem;
-    cursor: pointer;
-}
-
-.back-to-top:hover {
-    transform: translateY(-3px);
+    width: 22px;
+    height: 2px;
+    background: var(--text);
+    margin: 5px 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .sr-only {
@@ -539,107 +121,443 @@ textarea:focus-visible {
     margin: -1px;
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
     border: 0;
 }
 
+main {
+    padding: 0 clamp(1rem, 5vw, 5rem) 4rem;
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 3rem;
+    align-items: center;
+    padding: clamp(4rem, 8vw, 7rem) 0 3rem;
+}
+
+.hero--secondary {
+    padding-top: clamp(3rem, 7vw, 6rem);
+}
+
+.hero__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+
+.hero h1 {
+    font-size: clamp(2.6rem, 5vw, 4rem);
+    margin: 0.6rem 0 0.5rem;
+}
+
+.hero__tagline {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--muted);
+    margin-bottom: 1.5rem;
+}
+
+.hero__description {
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    max-width: 44ch;
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.hero__visual {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+    color: var(--muted-strong);
+}
+
+.hero__device {
+    border-radius: 32px;
+    height: clamp(220px, 28vw, 320px);
+    background: linear-gradient(145deg, rgba(255, 107, 107, 0.25), rgba(85, 150, 255, 0.25));
+    border: 1px solid var(--border);
+    box-shadow: 0 28px 60px rgba(17, 17, 40, 0.4);
+    position: relative;
+}
+
+.hero__device::after {
+    content: '';
+    position: absolute;
+    inset: 16px;
+    border-radius: 24px;
+    background: radial-gradient(circle at center, rgba(255, 130, 160, 0.8), rgba(10, 10, 28, 0.6));
+    box-shadow: inset 0 0 40px rgba(255, 130, 160, 0.35);
+}
+
+.hero__device--video::after {
+    background: radial-gradient(circle at center, rgba(85, 150, 255, 0.6), rgba(10, 12, 34, 0.7));
+    animation: pulse 4s ease-in-out infinite;
+}
+
 @keyframes pulse {
-    0% {
-        transform: scale(0.9);
-        opacity: 0.6;
-    }
-    50% {
-        transform: scale(1.05);
-        opacity: 1;
-    }
+    0%,
     100% {
-        transform: scale(0.9);
-        opacity: 0.6;
-    }
-}
-
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes float {
-    0%, 100% {
-        transform: translateY(0px);
+        opacity: 0.85;
     }
     50% {
-        transform: translateY(-10px);
+        opacity: 1;
     }
 }
 
-@media (max-width: 900px) {
-    .site-nav ul {
-        position: fixed;
-        inset: 0 0 auto 0;
-        background: rgba(4, 3, 15, 0.94);
-        flex-direction: column;
-        align-items: center;
-        padding: 5rem 1rem 2rem;
-        gap: 1.2rem;
-        transform: translateY(-120%);
-        transition: transform 0.4s ease;
-    }
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    font-weight: 700;
+    border: 1px solid transparent;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
 
-    .site-nav ul.is-open {
-        transform: translateY(0);
-    }
+.button--primary {
+    background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+    color: #080811;
+    box-shadow: 0 16px 30px rgba(255, 107, 107, 0.3);
+}
 
+.button--primary:hover,
+.button--primary:focus-visible {
+    transform: translateY(-2px);
+}
+
+.button--outline {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.45);
+    color: var(--text);
+}
+
+.button--ghost {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.2);
+    color: var(--muted);
+}
+
+.button--outline:hover,
+.button--ghost:hover,
+.button--outline:focus-visible,
+.button--ghost:focus-visible {
+    border-color: var(--accent);
+    color: var(--text);
+}
+
+.section {
+    padding: clamp(3rem, 6vw, 5rem) 0;
+    border-top: 1px solid var(--border);
+}
+
+.section:first-of-type {
+    border-top: none;
+}
+
+.section__header {
+    max-width: 60ch;
+    margin-bottom: 2rem;
+}
+
+.section__header > h1,
+.section__header > h2 {
+    margin-bottom: 1rem;
+}
+
+.section__intro {
+    color: var(--muted);
+    font-weight: 600;
+}
+
+.steps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.75rem;
+}
+
+.step {
+    padding: 1.5rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    box-shadow: 0 16px 30px rgba(9, 9, 22, 0.32);
+}
+
+.step h3 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
+.section__cta {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.section__cta .multimedia-note {
+    font-size: 0.85rem;
+    color: var(--muted-strong);
+}
+
+.notice {
+    background: rgba(16, 16, 32, 0.82);
+    border-block: 1px solid var(--border);
+    padding: 1.75rem 0;
+}
+
+.notice .container {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 0 clamp(1rem, 5vw, 4rem);
+    text-align: center;
+}
+
+.notice h2 {
+    margin-bottom: 0.75rem;
+}
+
+.notice p {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.impact {
+    padding-bottom: clamp(3rem, 6vw, 5rem);
+}
+
+.impact__header {
+    margin-bottom: 2rem;
+}
+
+.impact__header .tagline {
+    color: var(--muted);
+    font-weight: 700;
+    margin-top: 0.5rem;
+}
+
+.impact__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.8rem;
+}
+
+.impact__grid article {
+    background: var(--surface-alt);
+    padding: 1.75rem;
+    border-radius: 18px;
+    border: 1px solid var(--border);
+    color: var(--muted);
+}
+
+.impact__grid h3 {
+    color: var(--text);
+    margin-top: 0;
+}
+
+.media-callout {
+    background: var(--surface);
+    border-radius: 20px;
+    border: 1px solid var(--border);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.media-callout__media {
+    height: 220px;
+    border-radius: 16px;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    background: repeating-linear-gradient(135deg, rgba(255, 107, 107, 0.08), rgba(255, 107, 107, 0.08) 20px, rgba(85, 150, 255, 0.08) 20px, rgba(85, 150, 255, 0.08) 40px);
+}
+
+.multimedia-note {
+    font-size: 0.85rem;
+    color: var(--muted-strong);
+    margin: 0;
+}
+
+.process-list {
+    counter-reset: step;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.process-list li {
+    background: var(--surface);
+    border-radius: 18px;
+    padding: 1.75rem;
+    border: 1px solid var(--border);
+    position: relative;
+}
+
+.process-list li::before {
+    counter-increment: step;
+    content: counter(step);
+    position: absolute;
+    top: 18px;
+    right: 20px;
+    font-weight: 800;
+    font-size: 2rem;
+    color: rgba(255, 255, 255, 0.08);
+}
+
+.section--alt {
+    background: rgba(18, 18, 34, 0.6);
+}
+
+.services-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.8rem;
+}
+
+.services-grid article {
+    padding: 1.6rem;
+    border-radius: 18px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--muted);
+}
+
+.services-grid h2 {
+    color: var(--text);
+    margin-top: 0;
+}
+
+.pilot-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    align-items: start;
+}
+
+.pilot-grid figure,
+.pilot-grid div {
+    background: var(--surface);
+    padding: 1.5rem;
+    border-radius: 18px;
+    border: 1px solid var(--border);
+}
+
+.pilot-grid ul {
+    padding-left: 1.2rem;
+    color: var(--muted);
+}
+
+.pilot-grid .subtext {
+    color: var(--muted-strong);
+    font-size: 0.9rem;
+}
+
+.map-placeholder,
+.map-widget__placeholder {
+    height: 220px;
+    border-radius: 14px;
+    border: 1px dashed rgba(255, 255, 255, 0.25);
+    background: repeating-linear-gradient(45deg, rgba(85, 150, 255, 0.1), rgba(85, 150, 255, 0.1) 18px, rgba(255, 107, 107, 0.12) 18px, rgba(255, 107, 107, 0.12) 36px);
+}
+
+.checklist {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem;
+    display: grid;
+    gap: 0.8rem;
+}
+
+.checklist li::before {
+    content: '✔';
+    margin-right: 0.5rem;
+    color: var(--accent);
+}
+
+.map-widget {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.notice-text {
+    margin: 0;
+    color: var(--muted-strong);
+    font-size: 0.9rem;
+}
+
+.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 2rem clamp(1rem, 4vw, 4rem);
+    background: rgba(5, 5, 12, 0.9);
+    text-align: center;
+    color: var(--muted);
+}
+
+.footer__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.footer__content a {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.footer__content a:hover,
+.footer__content a:focus-visible {
+    color: var(--accent);
+}
+
+@media (max-width: 780px) {
     .nav-toggle {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-        background: transparent;
-        border: none;
-        cursor: pointer;
-    }
-
-    .nav-toggle span {
-        width: 26px;
-        height: 2px;
-        background: var(--text);
         display: block;
-        transition: transform 0.3s ease, opacity 0.3s ease;
     }
 
-    .nav-toggle[aria-expanded="true"] span:nth-child(1) {
-        transform: translateY(8px) rotate(45deg);
+    .site-nav {
+        position: absolute;
+        inset: calc(100% + 1px) 1rem auto;
+        background: rgba(5, 5, 12, 0.97);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 1rem;
+        transform: scaleY(0);
+        transform-origin: top;
+        transition: transform 0.2s ease;
     }
 
-    .nav-toggle[aria-expanded="true"] span:nth-child(2) {
-        opacity: 0;
+    .site-nav.is-open {
+        transform: scaleY(1);
     }
 
-    .nav-toggle[aria-expanded="true"] span:nth-child(3) {
-        transform: translateY(-8px) rotate(-45deg);
-    }
-}
-
-@media (max-width: 600px) {
-    main {
-        padding-bottom: 4rem;
-    }
-
-    .hero {
-        padding-top: 4rem;
-    }
-
-    .hero__actions {
-        width: 100%;
-    }
-
-    .hero__actions .button {
-        flex: 1;
-        text-align: center;
+    .site-nav ul {
+        flex-direction: column;
+        gap: 0.75rem;
     }
 }


### PR DESCRIPTION
## Summary
- replace the existing single-page layout with a dedicated homepage that follows the new messaging hierarchy
- add "How it works" and "Services" pages describing the process, ecosystem, and pilot program content from the script
- refresh shared styling and scripting to support the new structure, navigation, and accessibility notes

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68f0addddd3c8330ab6a5316d2540c83